### PR TITLE
ENH: adds user ID to query page by default

### DIFF
--- a/next/query_page/templates/query_page.html
+++ b/next/query_page/templates/query_page.html
@@ -28,6 +28,8 @@
           </div>
           <div class="modal-body">
             <h4 id="debrief_text">{{experiment['args']['debrief']}}</h4>
+            <br><br>
+            User ID: <div id="participant_uid"></div>
           </div>
         </div>
       </div>
@@ -50,6 +52,7 @@
       var div_id = "wrapper";
       var exp_uid = "{{exp_uid}}";
       var participant_uid = next_widget.makeRandomString(30);
+      $('#participant_uid').html(participant_uid);
       var args = {
           name: "getQuery",
           exp_uid: exp_uid,


### PR DESCRIPTION
In every psych experiment I've ever run, they've asked for some participant ID in the debrief. This adds that, and looks like below.

I want to hear feedback from some of the other developers before I make this change. I want this to be default for less documentation, to reduce the amount of duplicated code and because it's simpler.

<img width="935" alt="screen shot 2016-09-26 at 4 35 23 pm" src="https://cloud.githubusercontent.com/assets/1320475/18854269/c4577692-840f-11e6-9ec9-aa64fc8f79df.png">