### PR TITLE
added pythonic pop method for collection/database apis

### DIFF
--- a/next/apps/Butler.py
+++ b/next/apps/Butler.py
@@ -178,7 +178,17 @@ class Collection(object):
         Append a value to collection[uid][key] (which is assumed to be a list)
         """
         uid = (self.uid_prefix+uid).format(exp_uid=(self.exp_uid if exp == None else exp))
-        self.timed(self.db.append_list)(self.collection,uid,key,value)
+        self.timed(self.db.append_list)(self.collection, uid, key, value)
+
+    def pop(self, uid="", key=None, value=-1, exp=None):
+        """
+        Pop a value from collection[uid][key] (which is assumed to be a list)
+        value=-1 pops the last element of the list (default)
+        value=0 pops the first element of the list
+        Other values for "value" will throw error and return a None (not supported in Mongo)
+        """
+        uid = (self.uid_prefix+uid).format(exp_uid=(self.exp_uid if exp == None else exp))
+        return self.timed(self.db.pop_list, get=True)(self.collection, uid, key, value)
 
     def getDurations(self):
         """

--- a/next/database_client/DatabaseAPI.py
+++ b/next/database_client/DatabaseAPI.py
@@ -181,6 +181,10 @@ except:
     pass
 
 
+class DatabaseException(BaseException):
+    pass
+
+
 USE_CACHE = False
 
 class DatabaseAPI(object):
@@ -516,6 +520,31 @@ class DatabaseAPI(object):
 
         except:
             return None,False,'DatabaseAPI.get Failed with unknown exception'
+
+    def pop_list(self, bucket_id, doc_uid, key, value):
+        """
+        Inputs:
+            (string) bucket_id, (string) doc_uid, (string) key, (int) value
+            value=-1 pops the last item of the list
+            value=0 pops the first item of the list
+
+        Outputs:
+            (python object) value, (bool) didSucceed, (string) message
+
+        Usage: ::\n
+            didSucceed,message = db.pop_list(bucket_id,doc_uid,key,value)       
+        """
+
+        try:
+            response, dt = utils.timeit(self.permStore.pop_list)(constants.app_data_database_id,
+                                                                 bucket_id, doc_uid, key, value)
+            value, didSucceedPerm, messagePerm = response
+            self.duration_permStoreSet += dt
+            return value, didSucceedPerm, messagePerm
+        except Exception as e:
+            error = "DatabaseAPI.pop_list failed with exception: {}".format(e)
+            utils.debug_print(error)
+            return None, False, error
 
     def append_list(self,bucket_id,doc_uid,key,value):
         """

--- a/next/database_client/PermStore/PermStore.py
+++ b/next/database_client/PermStore/PermStore.py
@@ -130,6 +130,10 @@ import numpy as np
 import time
 
 
+class DatabaseException(BaseException):
+    pass
+
+
 class PermStore(object):
     """
     Acts as API to permanent store that can be passed around. Implements MongoDB
@@ -560,6 +564,62 @@ class PermStore(object):
         """
         return self.get(database_id,bucket_id,doc_uid,key)
 
+    def pop_list(self, database_id, bucket_id, doc_uid, key, value):
+        """
+        pops a value from a list.
+        If value=0, pops from start of list
+        If value=-1, pops from end of list.
+        (note this is inconsistent with Mongo's api to be consistent with python's pop)
+        See declaration of mongo_index for more info.
+        
+        Inputs: 
+            (string) database_id, (string) bucket_id, (string) doc_uid, (string) key, (int) value
+        
+        Outputs:
+            (any) value, (bool) didSucceed, (string) message 
+        
+        Usage: ::\n
+            value, didSucceed, message = db.set(database_id, bucket_id, doc_uid, key, value)
+        """
+        if self.client is None:
+            didSucceed, message = self.connectToMongoServer()
+            if not didSucceed:
+                return None, False, message
+        # For Mongo's $pop, 1 means last element, -1 means first element
+        try:
+            if value == -1:
+                mongo_index = 1
+            elif value == 0:
+                mongo_index = -1
+            else:
+                raise DatabaseException("can only pop first (value=0) or last (value=-1) element")
+            try:
+                return_value = self.client[database_id][bucket_id].find_one({"_id": doc_uid})[key]
+                self.client[database_id][bucket_id].update_one({"_id": doc_uid}, {'$pop': {key: mongo_index}})
+            except KeyError as e:
+                if e.args[0] == key:
+                    raise DatabaseException("key '{}' not found in document '{}.{}'".format(key, database_id, bucket_id))
+                elif e.args[0] == bucket_id:
+                    raise DatabaseException("bucket '{}' not found in database '{}'".format(bucket_id, database_id))
+                elif e.args[0] == database_id:
+                    raise DatabaseException("database '{}' not found".format(database_id))
+                else:
+                    raise DatabaseException("unknown KeyError: '{}' not found".format(e))
+            if isinstance(return_value, list):
+                if return_value:
+                    return_value = return_value[value]
+                else:
+                    raise DatabaseException("cannot pop from empty list")
+            else:
+                raise DatabaseException("cannot pop from non-list")
+            return_value = self.undoDatabaseFormat(return_value)
+
+            return return_value, True, 'From Mongo'
+        except DatabaseException as e:
+            error = "PermStore.pop_list failed with exception: {}".format(e)
+            utils.debug_print(error)
+            return None, False, error
+
     def append_list(self,database_id,bucket_id,doc_uid,key,value):
         """
         appends value to list saved by key. If key does not exist, sets {key:value}
@@ -585,9 +645,8 @@ class PermStore(object):
 
             return True,message
         except:
-            raise
             error = "MongoDB.set Failed with unknown exception"
-            return False,error
+            return False, error
 
     def set_list(self,database_id,bucket_id,doc_uid,key,value_list):
         """


### PR DESCRIPTION
This PR implements `collection.pop()` (as in `butler.algorithms.pop(key='foo')` or `butler.experiment.pop(key='foo')`) and mirrors a python list pop method.  That is, `butler.algorithms.pop(key='foo')` is equivalent to `foo.pop()` (will remove and return last item in list) and `butler.algorithms.pop(key='foo', value=0)` is equivalent to `foo.pop(0)` (will remove and return first item in list).  Due to mongo restrictions, only popping first or last item is allowed.  Attempting to pop another item, or trying to pop a non-list or empty list will raise a non-blocking exception and return a `None` and the underlying key/value pair will remain unchanged.

On that note, I've made a few changes to how `PermStore` handles exceptions, at least for this method.  Basically, there's a new exception class `DatabaseException`, and it `debug_print`s the exception when one happens.  I'd like to make similar changes to all of `PermStore`'s methods, but figured we can talk about that and have a separate PR for it.

Here's what you can expect - let me know if there's any other edge cases you'd like to see/handle differently:

``` python
    test_list = [1, 2, 3]
    test_string = 'this is a test'
    test_float = 1.23
    assert butler.algorithms.get(key='test') is None
    assert butler.algorithms.pop(key='test') is None  # PermStore.pop_list failed with exception: key 'test' not found in document 'app_data.TestApp:algorithms'
    assert butler.algorithms.get(key='test') is None
    butler.algorithms.set(key='test', value=test_list)
    assert butler.algorithms.pop(key='test') == test_list.pop()  # 3
    assert butler.algorithms.get(key='test') == test_list  # [1, 2]
    assert butler.algorithms.pop(key='test', value=1) is None  # PermStore.pop_list failed with exception: can only pop first (value=0) or last (value=-1) element
    assert butler.algorithms.pop(key='test', value=-1) == test_list.pop(-1)  # 2
    assert butler.algorithms.get(key='test') == test_list  # [1]
    assert butler.algorithms.pop(key='test') == test_list.pop()  # 1
    assert butler.algorithms.get(key='test') == []
    assert butler.algorithms.pop(key='test') is None  # PermStore.pop_list failed with exception: cannot pop from empty list
    assert butler.algorithms.get(key='test') == []
    butler.algorithms.set(key='test', value=test_string)
    assert butler.algorithms.pop(key='test') is None  # PermStore.pop_list failed with exception: cannot pop from non-list
    assert butler.algorithms.get(key='test') == test_string
    butler.algorithms.set(key='test', value=test_float)
    assert butler.algorithms.pop(key='test') is None  # PermStore.pop_list failed with exception: cannot pop from non-list
    assert butler.algorithms.get(key='test') == test_float
```