### PR TITLE
Fix init experiment & create Tests app

### DIFF
--- a/apps/CardinalBanditsPureExploration/tests/test_api.py
+++ b/apps/CardinalBanditsPureExploration/tests/test_api.py
@@ -12,10 +12,11 @@ from multiprocessing import Pool
 import sys
 import os
 try:
-        import next.apps.test_utils as test_utils
+    import next.apps.test_utils as test_utils
 except:
-        sys.path.append('../../next/apps')
-        import test_utils
+    file_dir = '/'.join(__file__.split('/')[:-1])
+    sys.path.append('{}/../../../next/apps'.format(file_dir))
+    import test_utils
 
 
 def test_api(assert_200=True, num_arms=5, num_experiments=1, num_clients=10, total_pulls=10):

--- a/apps/DuelingBanditsPureExploration/tests/test_api.py
+++ b/apps/DuelingBanditsPureExploration/tests/test_api.py
@@ -14,7 +14,8 @@ import sys
 try:
     import next.apps.test_utils as test_utils
 except:
-    sys.path.append('../../../next/apps')
+    file_dir = '/'.join(__file__.split('/')[:-1])
+    sys.path.append('{}/../../../next/apps'.format(file_dir))
     import test_utils
 
 

--- a/apps/PoolBasedBinaryClassification/tests/test_api.py
+++ b/apps/PoolBasedBinaryClassification/tests/test_api.py
@@ -10,7 +10,8 @@ import os, sys
 try:
     import next.apps.test_utils as test_utils
 except:
-    sys.path.append('../../../next/apps')
+    file_dir = '/'.join(__file__.split('/')[:-1])
+    sys.path.append('{}/../../../next/apps'.format(file_dir))
     import test_utils
 
 

--- a/apps/PoolBasedTripletMDS/tests/test_api.py
+++ b/apps/PoolBasedTripletMDS/tests/test_api.py
@@ -11,7 +11,8 @@ import sys
 try:
     import next.apps.test_utils as test_utils
 except:
-    sys.path.append('../../../next/apps')
+    file_dir = '/'.join(__file__.split('/')[:-1])
+    sys.path.append('{}/../../../next/apps'.format(file_dir))
     import test_utils
 
 app_id = 'PoolBasedTripletMDS'

--- a/apps/Tests/__init__.py
+++ b/apps/Tests/__init__.py
@@ -1,0 +1,1 @@
+from .myApp import *

--- a/apps/Tests/algs/Algs.yaml
+++ b/apps/Tests/algs/Algs.yaml
@@ -1,0 +1,24 @@
+initExp:
+  args:
+    dummy:
+      type: bool
+      description: This is here because there's a bug that requires myAlg.initExp to have at least one argument.
+      default: true
+  rets:
+    type: bool
+    values: true
+
+getQuery:
+  rets:
+    type: bool
+    values: true
+
+processAnswer:
+    rets:
+      type: bool
+      values: true
+
+getModel:
+  rets:
+    type: bool
+    values: true

--- a/apps/Tests/algs/TestAlg.py
+++ b/apps/Tests/algs/TestAlg.py
@@ -1,0 +1,25 @@
+
+class MyAlg:
+    def initExp(self, butler, dummy):
+
+        butler.algorithms.set(key='algorithms_foo', value='algorithms_bar')
+
+        return True
+
+    def getQuery(self, butler):
+
+        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
+        assert butler.algorithms.get(key='algorithms_foo') == 'algorithms_bar'
+
+        return True
+
+    def processAnswer(self, butler):
+
+        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
+        assert butler.algorithms.get(key='algorithms_foo') == 'algorithms_bar'
+
+        return True
+
+    def getModel(self, butler):
+
+        return True

--- a/apps/Tests/dashboard/Dashboard.py
+++ b/apps/Tests/dashboard/Dashboard.py
@@ -1,0 +1,5 @@
+from next.apps.AppDashboard import AppDashboard
+
+
+class MyAppDashboard(AppDashboard):
+    pass

--- a/apps/Tests/dashboard/myAppDashboard.html
+++ b/apps/Tests/dashboard/myAppDashboard.html
@@ -1,0 +1,2 @@
+
+{% extends "basic.html" %}

--- a/apps/Tests/myApp.py
+++ b/apps/Tests/myApp.py
@@ -1,0 +1,38 @@
+import json
+import next.utils as utils
+import next.apps.SimpleTargetManager
+
+class MyApp:
+    def __init__(self,db):
+        self.app_id = 'Tests'
+        self.TargetManager = next.apps.SimpleTargetManager.SimpleTargetManager(db)
+
+    def initExp(self, butler, init_algs, args):
+
+        butler.experiment.set(key='experiment_foo', value='experiment_bar')
+
+        init_algs({})
+
+        return args
+
+    def getQuery(self, butler, alg, args):
+
+        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
+
+        assert alg()
+
+        return {}
+
+    def processAnswer(self, butler, alg, args):
+
+        assert alg({})
+
+        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
+
+        return {}
+
+    def getModel(self, butler, alg, args):
+
+        assert alg()
+
+        return True

--- a/apps/Tests/myApp.yaml
+++ b/apps/Tests/myApp.yaml
@@ -1,0 +1,12 @@
+extends: [base.yaml]
+initExp:
+  args:
+    app_id:
+      values: [Tests]
+    args:
+      values:
+        alg_list:
+          values:
+            values:
+              alg_id:
+                values: [TestAlg]

--- a/apps/Tests/tests/test_api.py
+++ b/apps/Tests/tests/test_api.py
@@ -1,0 +1,120 @@
+import numpy
+import numpy.random
+import random
+import json
+import time
+import requests
+from scipy.linalg import norm
+from multiprocessing import Pool
+import os
+import sys
+try:
+    import next.apps.test_utils as test_utils
+except:
+    file_dir = '/'.join(__file__.split('/')[:-1])
+    sys.path.append('{}/../../../next/apps'.format(file_dir))
+    import test_utils
+
+app_id = 'Tests'
+
+
+def test_api(assert_200=True, num_objects=5, desired_dimension=2,
+            total_pulls_per_client=4, num_experiments=1, num_clients=6):
+
+    pool = Pool(processes=num_clients)
+    supported_alg_ids = ['TestAlg']
+    alg_list = []
+    for idx, alg_id in enumerate(supported_alg_ids):
+        alg_item = {}
+        alg_item['alg_id'] = alg_id
+        alg_item['alg_label'] = alg_id
+        alg_list.append(alg_item)
+
+    params = []
+    for algorithm in alg_list:
+        params.append({'alg_label': algorithm['alg_label'],
+                       'proportion': 1./len(alg_list)})
+    algorithm_management_settings = {}
+    algorithm_management_settings['mode'] = 'fixed_proportions'
+    algorithm_management_settings['params'] = params
+
+    # Test POST Experiment
+    initExp_args_dict = {}
+    initExp_args_dict['app_id'] = 'Tests'
+    initExp_args_dict['args'] = {}
+    initExp_args_dict['args']['participant_to_algorithm_management'] = 'one_to_many'
+    initExp_args_dict['args']['algorithm_management_settings'] = algorithm_management_settings
+    initExp_args_dict['args']['alg_list'] = alg_list
+    initExp_args_dict['args']['instructions'] = 'You want instructions, here are your test instructions'
+    initExp_args_dict['args']['debrief'] = 'You want a debrief, here is your test debrief'
+    initExp_args_dict['args']['targets'] = {}
+    initExp_args_dict['args']['targets']['n'] = num_objects
+
+    exp_info = []
+    for ell in range(num_experiments):
+        initExp_response_dict, exp_uid = test_utils.initExp(initExp_args_dict)
+        exp_info += [exp_uid]
+
+    # Generate participants
+    participants = []
+    pool_args = []
+    for i in range(num_clients):
+        participant_uid = '%030x' % random.randrange(16**30)
+        participants.append(participant_uid)
+
+        experiment = numpy.random.choice(exp_info)
+        exp_uid = experiment['exp_uid']
+        pool_args.append((exp_uid, participant_uid, total_pulls_per_client, assert_200))
+    results = pool.map(simulate_one_client, pool_args)
+
+    for result in results:
+        print result
+
+    test_utils.getModel(exp_uid, app_id, supported_alg_ids, alg_list)
+
+
+def simulate_one_client(input_args):
+
+    exp_uid, participant_uid, total_pulls, assert_200 = input_args
+
+    getQuery_times = []
+    processAnswer_times = []
+
+    for t in range(total_pulls):
+        print "Participant {1} has taken {0} pulls".format(t, participant_uid)
+        # test POST getQuery #
+        widget = random.choice([True] + 4*[False])
+        widget = True
+        getQuery_args_dict = {'args': {'participant_uid': participant_uid,
+                                       'widget': widget},
+                              'exp_uid': exp_uid}
+
+        query_dict, dt = test_utils.getQuery(getQuery_args_dict)
+        getQuery_times += [dt]
+
+        if widget:
+            query_dict = query_dict['args']
+        query_uid = query_dict['query_uid']
+
+        ts = test_utils.response_delay()
+        # sleep for a bit to simulate response time
+
+        response_time = time.time() - ts
+
+        # test POST processAnswer
+        processAnswer_args_dict = {}
+        processAnswer_args_dict["exp_uid"] = exp_uid
+        processAnswer_args_dict["args"] = {}
+        processAnswer_args_dict["args"]["query_uid"] = query_uid
+        processAnswer_args_dict["args"]['response_time'] = response_time
+
+        processAnswer_json_response, dt = test_utils.processAnswer(processAnswer_args_dict)
+        processAnswer_times.append(dt)
+
+    r = test_utils.format_times(getQuery_times, processAnswer_times, total_pulls,
+            participant_uid)
+
+    return r
+
+if __name__ == '__main__':
+    test_api()

--- a/next/apps/App.py
+++ b/next/apps/App.py
@@ -102,9 +102,10 @@ class App(object):
             args_dict['start_date'] = utils.datetime2str(utils.datetimeNow())
             self.butler.admin.set(uid=exp_uid,value={'exp_uid': exp_uid, 'app_id':self.app_id, 'start_date':str(utils.datetimeNow())})            
             utils.debug_print("ASD "+str(args_dict))
+            self.butler.experiment.set(value={'exp_uid': exp_uid})
             args_dict['args'] = self.init_app(exp_uid, args_dict['args']['alg_list'], args_dict['args'])
             args_dict['git_hash'] = git_hash
-            self.butler.experiment.set(value=args_dict)
+            self.butler.experiment.set_many(key_value_dict=args_dict)
             return '{}', True, ''
         except Exception, error:
             exc_type, exc_value, exc_traceback = sys.exc_info()


### PR DESCRIPTION
This commit fixes #160 by initializing the butler.experiments collection as a document containing only the `exp_uid` before calling `myApp.initExp`.

The problem before was that if someone called `butler.experiment.set(key='foo', value='bar')` in `myApp.initExp`, it would initialize the experiment collection as a document which didn't have the `exp_uid` in it which would create all kinds of hard-to-debug errors down the road.

In this commit, I've also created a `Tests` app, which is a minimal app for us to write integrated tests for all kinds of stuff (testing the database API, for example).  For example, I wrote a test that demonstrates that you can now set an arbitrary key using `butler.experiments.set` in `myApp.initExp`.

I've run all tests locally (including new ones) with no errors.