### PR TITLE
updated to celery 4.0

### DIFF
--- a/next/base_docker_image/requirements.txt
+++ b/next/base_docker_image/requirements.txt
@@ -4,7 +4,7 @@ Flask-Login
 gunicorn
 pymongo
 redis
-celery==3.1.25
+celery
 boto
 greenlet
 mpld3

--- a/next/broker/celery_app/tasks.py
+++ b/next/broker/celery_app/tasks.py
@@ -172,6 +172,12 @@ def seed_rng(**_):
     """
     numpy.random.seed()
 
+
+@celery.signals.worker_ready.connect
+def worker_is_ready(**kwargs):
+    next.utils.debug_print("{} ready.".format(kwargs['sender'].hostname))
+
+
 # If celery isn't off, celery-wrap the functions so they can be called with apply_async
 if next.constants.CELERY_ON:
         apply = app.task(apply)

--- a/next/broker/next_worker_startup.sh
+++ b/next/broker/next_worker_startup.sh
@@ -2,27 +2,25 @@
 
 for i in `seq 2 $CELERY_ASYNC_WORKER_COUNT`
 do
-    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_ASYNC_WORKER} -n async_worker_${i}@${HOSTNAME} -Q async@${HOSTNAME} -- celeryd.prefetch_multiplier=${CELERY_ASYNC_WORKER_PREFETCH} &
+    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_ASYNC_WORKER} -n async_worker_${i}@${HOSTNAME} -Q async@${HOSTNAME} --prefetch-multiplier=${CELERY_ASYNC_WORKER_PREFETCH} &
 done
 
 for i in `seq 2 $CELERY_DASHBOARD_WORKER_COUNT`
 do
-    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_DASHBOARD_WORKER} -n dashboard_worker_${i}@${HOSTNAME} -Q dashboard@${HOSTNAME} -- celeryd.prefetch_multiplier=${CELERY_DASHBOARD_WORKER_PREFETCH} &
+    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_DASHBOARD_WORKER} -n dashboard_worker_${i}@${HOSTNAME} -Q dashboard@${HOSTNAME} --prefetch-multiplier=${CELERY_DASHBOARD_WORKER_PREFETCH} &
 done
 
 for i in `seq 2 $CELERY_SYNC_WORKER_COUNT`
 do
-    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=1 -n sync_worker_${i}@${HOSTNAME} -Q sync_queue_${i}@${HOSTNAME} -- celeryd.prefetch_multiplier=1  &
+    celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=1 -n sync_worker_${i}@${HOSTNAME} -Q sync_queue_${i}@${HOSTNAME} --prefetch-multiplier=1 &
 done
 
 
-
-
 export i=1
-celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_ASYNC_WORKER} -n async_worker_${i}@${HOSTNAME} -Q async@${HOSTNAME} -- celeryd.prefetch_multiplier=${CELERY_ASYNC_WORKER_PREFETCH} &
-celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=1 -n sync_worker_${i}@${HOSTNAME} -Q sync_queue_${i}@${HOSTNAME} -- celeryd.prefetch_multiplier=1 &
-celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_DASHBOARD_WORKER} -n dashboard_worker_${i}@${HOSTNAME} -Q dashboard@${HOSTNAME} -- celeryd.prefetch_multiplier=${CELERY_DASHBOARD_WORKER_PREFETCH} 
 
+celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_ASYNC_WORKER} -n async_worker_${i}@${HOSTNAME} -Q async@${HOSTNAME} --prefetch-multiplier=${CELERY_ASYNC_WORKER_PREFETCH} &
+celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=1 -n sync_worker_${i}@${HOSTNAME} -Q sync_queue_${i}@${HOSTNAME} --prefetch-multiplier=1 &
+celery -A next.broker.celery_app worker -l info --loglevel=WARNING --concurrency=${CELERY_THREADS_PER_DASHBOARD_WORKER} -n dashboard_worker_${i}@${HOSTNAME} -Q dashboard@${HOSTNAME} --prefetch-multiplier=${CELERY_DASHBOARD_WORKER_PREFETCH}
 
 # celery -A next.broker.celery_app worker -l info --loglevel=info --concurrency=1 -n async_queue_worker_$i@%h -Q global_pool,async_queue_$HOSTNAME &
 # celery -A next.broker.celery_app worker -l info --loglevel=info --concurrency=$CELERY_THREADS_PER_WORKER -n sync_queue_worker_1@%h -Q global_pool,sync_queue_$HOSTNAME


### PR DESCRIPTION
as per #159 this updates to celery 4.0

Changes:

- changed requirements file for docker image (no longer `celery==3.1.25`)
- Added a celery.worker_ready function that debug prints to console (basically just mimicking the celery 3 behavior (e.g. `sync_worker_2@2affb02ed780 ready.`), which is no longer the default)
- updated celery cli options in `next_worker_startup.sh` to reflect new new version of celery. (this is what was causing it not to work before)

Note that I didn't mess with any of the options in `next.constants` - they are transitioning from upper case to lower case but our constants as is will be supported until celery 5 (?).  I tried running their "automatically fix it" script and it broke things so I didn't bother...  see http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#step-2-update-your-configuration-with-the-new-setting-names
