### PR TITLE
Fix memory algorithms namespace

### DIFF
--- a/next/apps/Butler.py
+++ b/next/apps/Butler.py
@@ -6,8 +6,8 @@ import StringIO
 
 
 class Memory(object):
-    def __init__(self, collection='', exp_uid=''):
-        self.key_prefix = collection + exp_uid
+    def __init__(self, collection='', exp_uid='', uid_prefix=''):
+        self.key_prefix = collection + uid_prefix.format(exp_uid=exp_uid)
         self.cache = None
         self.max_entry_size = 500000000  # 500MB
 

--- a/next/apps/Butler.py
+++ b/next/apps/Butler.py
@@ -132,7 +132,7 @@ class Collection(object):
         self.get_durations = 0.0
         self.set_durations = 0.0
         self.timing = timing
-        self.memory = Memory(collection, exp_uid)
+        self.memory = Memory(collection, exp_uid, uid_prefix)
 
     def set(self, uid="", key=None, value=None, exp=None):
         """


### PR DESCRIPTION
Fixes #184 
Before if you had two algorithms, they would both save using the same `<app_id>:algorithms_<exp_uid>` key_prefix.  Now we include alg_label in the key_prefix so there are no conflicts if you have multiple algorithms.