### PR TITLE
Give Butler.Collections and Butler.Memory the python dict-api

### DIFF
--- a/apps/Tests/algs/Algs.yaml
+++ b/apps/Tests/algs/Algs.yaml
@@ -5,20 +5,16 @@ initExp:
       description: This is here because there's a bug that requires myAlg.initExp to have at least one argument.
       default: true
   rets:
-    type: bool
-    values: true
+    type: str
 
 getQuery:
   rets:
-    type: bool
-    values: true
+    type: str
 
 processAnswer:
     rets:
-      type: bool
-      values: true
+      type: str
 
 getModel:
   rets:
-    type: bool
-    values: true
+    type: str

--- a/apps/Tests/algs/TestAlg.py
+++ b/apps/Tests/algs/TestAlg.py
@@ -1,25 +1,22 @@
+from apps.Tests.tests.test_api import set_and_get_alg, get_alg, get_exp
+
 
 class MyAlg:
     def initExp(self, butler, dummy):
-
-        butler.algorithms.set(key='algorithms_foo', value='algorithms_bar')
-
-        return True
+        get_exp(butler)
+        set_and_get_alg(butler)
+        return "return_init_exp"
 
     def getQuery(self, butler):
-
-        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
-        assert butler.algorithms.get(key='algorithms_foo') == 'algorithms_bar'
-
-        return True
+        get_alg(butler)
+        return "return_get_query"
 
     def processAnswer(self, butler):
-
-        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
-        assert butler.algorithms.get(key='algorithms_foo') == 'algorithms_bar'
-
-        return True
+        get_alg(butler)
+        return "return_process_answer"
 
     def getModel(self, butler):
+        get_alg(butler)
+        return "return_process_answer"
 
-        return True
+

--- a/apps/Tests/myApp.py
+++ b/apps/Tests/myApp.py
@@ -1,6 +1,6 @@
-import json
-import next.utils as utils
 import next.apps.SimpleTargetManager
+from apps.Tests.tests.test_api import get_alg, get_exp, set_and_get_exp
+
 
 class MyApp:
     def __init__(self,db):
@@ -8,31 +8,23 @@ class MyApp:
         self.TargetManager = next.apps.SimpleTargetManager.SimpleTargetManager(db)
 
     def initExp(self, butler, init_algs, args):
-
-        butler.experiment.set(key='experiment_foo', value='experiment_bar')
-
+        set_and_get_exp(butler)
         init_algs({})
-
         return args
 
     def getQuery(self, butler, alg, args):
-
-        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
-
-        assert alg()
-
+        get_exp(butler)
+        assert alg() == "return_get_query"
         return {}
 
     def processAnswer(self, butler, alg, args):
-
-        assert alg({})
-
-        assert butler.experiment.get(key='experiment_foo') == 'experiment_bar'
-
+        get_exp(butler)
+        assert alg({}) == "return_process_answer"
         return {}
 
     def getModel(self, butler, alg, args):
-
-        assert alg()
-
+        get_exp(butler)
+        assert alg() == "return_get_model"
         return True
+
+

--- a/apps/Tests/tests/test_api.py
+++ b/apps/Tests/tests/test_api.py
@@ -1,12 +1,8 @@
 import numpy
 import numpy.random
 import random
-import json
 import time
-import requests
-from scipy.linalg import norm
 from multiprocessing import Pool
-import os
 import sys
 try:
     import next.apps.test_utils as test_utils
@@ -115,6 +111,36 @@ def simulate_one_client(input_args):
             participant_uid)
 
     return r
+
+
+def set_and_get_exp(butler):
+    butler.experiment['exp_key_1'] = 'exp_value_1'
+    butler.experiment.set(key='exp_key_2', value='exp_value_2')
+    butler.experiment.memory['exp_key_mem_1'] = 'exp_value_mem_1'
+    butler.experiment.memory.set(key='exp_key_mem_2', value='exp_value_mem_2')
+    get_exp(butler)
+
+
+def get_exp(butler):
+    assert butler.experiment['exp_key_1'] == butler.experiment.get(key='exp_key_1') == 'exp_value_1'
+    assert butler.experiment['exp_key_2'] == butler.experiment.get(key='exp_key_2') == 'exp_value_2'
+    assert butler.experiment.memory['exp_key_mem_1'] == butler.experiment.memory.get(key='exp_key_mem_1') == 'exp_value_mem_1'
+    assert butler.experiment.memory['exp_key_mem_2'] == butler.experiment.memory.get(key='exp_key_mem_2') == 'exp_value_mem_2'
+
+
+def set_and_get_alg(butler):
+    butler.algorithms['alg_key_1'] = 'alg_value_1'
+    butler.algorithms.set(key='alg_key_2', value='alg_value_2')
+    butler.algorithms.memory['alg_key_mem_1'] = 'alg_value_mem_1'
+    butler.algorithms.memory.set(key='alg_key_mem_2', value='alg_value_mem_2')
+    get_alg(butler)
+
+
+def get_alg(butler):
+    assert butler.algorithms['alg_key_1'] == butler.algorithms.get(key='alg_key_1') == 'alg_value_1'
+    assert butler.algorithms['alg_key_2'] == butler.algorithms.get(key='alg_key_2') == 'alg_value_2'
+    assert butler.algorithms.memory['alg_key_mem_1'] == butler.algorithms.memory.get(key='alg_key_mem_1') == 'alg_value_mem_1'
+    assert butler.algorithms.memory['alg_key_mem_2'] == butler.algorithms.memory.get(key='alg_key_mem_2') == 'alg_value_mem_2'
 
 if __name__ == '__main__':
     test_api()

--- a/next/apps/Butler.py
+++ b/next/apps/Butler.py
@@ -8,7 +8,21 @@ import next.constants as constants
 import next.utils as utils
 
 
-class Memory(object):
+class NextDictionary(object):
+    def get(self, key):
+        raise NotImplementedError
+
+    def set(self, key, value):
+        raise NotImplementedError
+
+    def __getitem__(self, item):
+        return self.get(key=item)
+
+    def __setitem__(self, key, value):
+        self.set(key=key, value=value)
+
+
+class Memory(NextDictionary):
     def __init__(self, collection='', exp_uid='', uid_prefix=''):
         self.key_prefix = collection + uid_prefix.format(exp_uid=exp_uid)
         self.cache = None
@@ -126,7 +140,7 @@ class Memory(object):
             return None
 
 
-class Collection(object):
+class Collection(NextDictionary):
     def __init__(self, collection, uid_prefix, exp_uid, db, timing=True):
         self.collection = collection
         self.db = db


### PR DESCRIPTION
Allows you to use dict-like api for Collections.  e.g. `butler.experiment["foo"] = "bar"` instead of `butler.experiment.set(key="foo", value="bar")`.

New tests in Tests app to test this.

I also refactored the Tests app a little more.  It probably could be cleaned up a bunch more to do more unit test-y things but it's good for now.