### PR TITLE
ENH: adding targets endpoint

### DIFF
--- a/next/api/api_blueprint.py
+++ b/next/api/api_blueprint.py
@@ -36,3 +36,6 @@ from next.api.resources.participants import Participants
 api_interface.add_resource(Participants,
                            '/experiment/<string:exp_uid>/participants')
 
+from next.api.resources.targets import Targets
+api_interface.add_resource(Targets,
+                           '/experiment/<string:exp_uid>/targets')

--- a/next/api/resources/targets.py
+++ b/next/api/resources/targets.py
@@ -1,0 +1,48 @@
+from StringIO import StringIO
+import pandas as pd
+from flask import Flask, send_file, request, abort
+from flask_restful import Resource, reqparse
+import traceback
+
+import json
+from io import BytesIO
+import zipfile
+
+import next.utils
+import next.utils as utils
+import next.api.api_util as api_util
+from next.api.api_util import APIArgument
+from next.api.resource_manager import ResourceManager
+from next.database_client.DatabaseAPI import DatabaseAPI
+from next.logging_client.LoggerAPI import LoggerAPI
+from next.apps.App import App
+db = DatabaseAPI()
+ell = LoggerAPI()
+
+resource_manager = ResourceManager()
+
+# Request parser. Checks that necessary dictionary keys are available in a given resource.
+# We rely on learningLib functions to ensure that all necessary arguments are available and parsed.
+post_parser = reqparse.RequestParser(argument_class=APIArgument)
+
+# Custom errors for GET and POST verbs on experiment resource
+meta_error = {
+    'ExpDoesNotExistError': {
+        'message': "No experiment with the specified experiment ID exists.",
+        'code': 400,
+        'status':'FAIL'
+    },
+}
+
+meta_success = {
+    'code': 200,
+    'status': 'OK'
+}
+
+# Participants resource class
+class Targets(Resource):
+    def get(self, exp_uid):
+        app_id = resource_manager.get_app_id(exp_uid)
+        app = App(app_id, exp_uid, db, ell)
+        butler = app.butler
+        return butler.targets.get_targetset(exp_uid)

--- a/next/assistant/target_unpacker.py
+++ b/next/assistant/target_unpacker.py
@@ -103,7 +103,8 @@ def unpack_text_file(s, kind='csv'):
     # files is has at least one key; (tested before call in assistant_blueprint.py)
     file_str = files[files.keys()[0]]
     if kind in {'csv', 'txt'}:
-        strings = file_str.split('\n')[:-1]  # -1 because last newline
+        strings = file_str.split('\n')  # -1 because last newline
+        strings = list(filter(lambda x: len(x) > 0, strings))
         targets = [{'target_id': str(i),
                     'primary_type': 'text',
                     'primary_description': string,

--- a/next/dashboard/templates/basic.html
+++ b/next/dashboard/templates/basic.html
@@ -80,6 +80,7 @@ popup_alert = function(text){
             <b> Backend Exceptions: </b> <a href="/api/experiment/{{ exp_uid }}/logs/APP-EXCEPTION" target="_blank">Open in new tab</a>  <br>
             <b> Experiment data: </b> <a href="/api/experiment/{{ exp_uid }}" target="_blank">Open in new tab</a>  <br>
             <b> Query page: </b> <a href="/query/query_page/query_page/{{ exp_uid }}" target="_blank">Open in new tab</a>  <br>
+            <b> Targets: </b> <a href="/api/experiment/{{exp_uid}}/targets" target="_blank">Open in new tab</a><br>
             <b> Participant data: </b> <a href="/api/experiment/{{ exp_uid }}/participants?zip=1" target="_blank">JSON</a>,
             <a href="/api/experiment/{{ exp_uid
                 }}/participants?csv=1&zip=1" target="_blank">CSV</a>


### PR DESCRIPTION
The target order is unknown when uploading a zip file of images. This PR resolves that problem by adding a `/api/experiment/{exp_uid}/targets` endpoint.

This PR is a minimal solution to get results (as in #189).