### PR TITLE
MAINT: show participant ID on bottom of page

### DIFF
--- a/next/query_page/templates/query_page.html
+++ b/next/query_page/templates/query_page.html
@@ -44,9 +44,9 @@
       <div id="wrapper">
         <center><h1>Loading...</h1></center>
       </div>
-    <div class="navbar navbar-default navbar-fixed-bottom">
+    <div class="navbar navbar-default navbar-fixed-bottom" style="height: 2em; min-height: 20px;">
       <div class="container">
-        User ID: <span id="participant_uid_bottom"></span>
+        <p>User ID: <span id="participant_uid_bottom"></span></p>
       </div>
     </div>
 

--- a/next/query_page/templates/query_page.html
+++ b/next/query_page/templates/query_page.html
@@ -44,6 +44,10 @@
       <div id="wrapper">
         <center><h1>Loading...</h1></center>
       </div>
+    <div class="navbar navbar-default navbar-fixed-bottom">
+      <div class="container">
+        User ID: <span id="participant_uid_bottom"></span>
+      </div>
     </div>
 
     <script>
@@ -59,6 +63,7 @@
       {% endif %}
 
       $('#participant_uid').html(participant_uid);
+      $('#participant_uid_bottom').html(participant_uid);
       var args = {
           name: "getQuery",
           exp_uid: exp_uid,


### PR DESCRIPTION
Resolves #213 and uses bootstrap (so scales nice with height/width).

This should be present for the people who use NEXT for crowdsourcing. I've included it on the default query page, which I think is the most practical option.

<img width="1104" alt="screen shot 2018-01-11 at 5 12 55 pm" src="https://user-images.githubusercontent.com/1320475/34852244-97a1bbdc-f725-11e7-852f-090a4514fd8a.png">
