### PR TITLE
MAINT, ENH, TST: Butler.Memory

### DIFF
--- a/ec2/templates/docker-compose.yml
+++ b/ec2/templates/docker-compose.yml
@@ -65,6 +65,7 @@ nextbackenddocker:
     - rabbitmqredis:RABBITREDIS
     - mongodb:MONGODB
     - minionworker:MINIONWORKER
+    - minionredis:6379
   environment:
    - PYTHONUNBUFFERED=TRUE
    - PYTHONPATH=:/next_backend

--- a/local/docker-compose.yml.pre
+++ b/local/docker-compose.yml.pre
@@ -66,6 +66,7 @@ nextbackenddocker:
     - rabbitmqredis:RABBITREDIS
     - mongodb:MONGODB
     - minionworker:MINIONWORKER
+    - minionredis:6379
   environment:
    - PYTHONUNBUFFERED=TRUE
    - PYTHONPATH=:/next_backend

--- a/next/apps/tests/test_memory.py
+++ b/next/apps/tests/test_memory.py
@@ -1,0 +1,82 @@
+import sys
+import pytest
+import numpy as np
+import itertools
+try:
+    from next.apps.Butler import Memory
+except:
+    sys.path.append('..')
+    sys.path.append('../..')
+    sys.path.append('../../..')
+    sys.path.append('../../../..')
+    from Butler import Memory
+
+
+def test_ensure_connection():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem._ensure_connection()
+
+
+@pytest.mark.parametrize("value", [
+    'bar', 1, 2, {'dict': True}, ('tuple', True),
+    [1, 2, 3], ['1', '2']
+])
+def test_set_and_get(value):
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem.set('foo-gs', value)
+    assert mem.get('foo-gs') == value
+
+
+def test_exists():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem.set('foo-exist', 'bar')
+    assert mem.exists('foo-exist')
+
+
+def test_append():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem.set('foo-append2', [1, 2, 3])
+    assert mem.append('foo-append2', [4])
+    assert mem.get('foo-append2') == [1, 2, 3, 4]
+
+def test_append_no_initial():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    for i in itertools.count(start=0, step=1):
+        key = 'foo-append' + str(hash(i))
+        if mem.exists(key):
+            continue
+        mem.append(key, [4])
+        assert mem.get(key) == [4]
+        break
+
+
+def test_get_ndarray():
+    x = np.linspace(0, 1)
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem.set('x', x)
+    y = mem.get('x')
+    assert np.allclose(x, y)
+
+
+def test_increment():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    mem.set('foo-incr', 0)
+    assert mem.increment('foo-incr') == 1
+    assert mem.increment('foo-incr', value=2) == 3
+
+def test_set_many():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    values = {'a': 1, 'b': 2}
+    mem.set_many(values)
+
+    out = {k: mem.get(k) for k in values}
+    assert out == values
+
+def test_get_many():
+    mem = Memory(exp_uid=hash(1), uid_prefix='abc')
+    values = {'a': 1, 'b': 2}
+    for k, v in values.items():
+        mem.set(k, v)
+    keys = list(values.keys())
+    out = mem.get_many(keys)
+    assert values == out

--- a/next/base_docker_image/requirements.txt
+++ b/next/base_docker_image/requirements.txt
@@ -30,6 +30,7 @@ ply==3.10
 pymongo==3.4.0
 pyparsing==2.2.0
 python-dateutil==2.6.1
+pytest==3.2.1
 pytz==2017.2
 PyYAML==3.12
 redis==2.10.5


### PR DESCRIPTION
This request provides two items:

- better connection for butler.memory
- more complete interface to butler.memory
- cleans the Memory API

The "better connection" means that it does not rely on `constants.MINIONREDISHOST`. For me that failed. Instead, uses `StrictRedis(host='minionredis_1')`, which is (as @dconathan mentioned) a somewhat old docker feature that we're not up to date on. @liamim did `constants.MINIONREDISHOST` work for you?

This also adds the functions `increment`, `append`, `get_many`, `set_many` and `pipeline` to Butler.Memory. It also refactors `set` and `get` to use `ast.literal_eval` to return the stored objects.

It cleans the API by using function wrappers to ensure the connection and catch exceptions. Before, all of these were coded in every function.

This implementation can be tested in the docker container with

``` shell
$ sudo docker exec -i -t local_nextbackenddocker_1 /bin/bash
# logs into docker container
$ cd next/apps/tests
$ py.test test_memory.py
```

All tests pass.